### PR TITLE
show alert above keyboard, inherit global tintColor

### DIFF
--- a/Pod/Classes/UIAlertController+Window.m
+++ b/Pod/Classes/UIAlertController+Window.m
@@ -38,7 +38,13 @@
 - (void)show:(BOOL)animated {
     self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     self.alertWindow.rootViewController = [[UIViewController alloc] init];
-    self.alertWindow.windowLevel = UIWindowLevelAlert + 1;
+    
+    // we inherit the main window's tintColor
+    self.alertWindow.tintColor = [UIApplication sharedApplication].delegate.window.tintColor;
+    // window level is above the top window (this makes the alert, if it's a sheet, show over the keyboard)
+    UIWindow *topWindow = [UIApplication sharedApplication].windows.lastObject;
+    self.alertWindow.windowLevel = topWindow.windowLevel + 1;
+    
     [self.alertWindow makeKeyAndVisible];
     [self.alertWindow.rootViewController presentViewController:self animated:animated completion:nil];
 }


### PR DESCRIPTION
See http://stackoverflow.com/questions/28564710/keep-keyboard-on-when-uialertcontroller-is-presented-in-swift
