### PR TITLE
added a tintColor property to allow the ability to set the tintColor …

### DIFF
--- a/Pod/Classes/UIAlertController+Window.h
+++ b/Pod/Classes/UIAlertController+Window.h
@@ -7,10 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
-
+NS_ASSUME_NONNULL_BEGIN
 @interface UIAlertController (Window)
-
++ (instancetype)alertControllerWithTitle:(nullable NSString *)title message:(nullable NSString *)message preferredStyle:(UIAlertControllerStyle)preferredStyle tintColor:(nullable UIColor *)tintColor;
 - (void)show;
 - (void)show:(BOOL)animated;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/UIAlertController+Window.m
+++ b/Pod/Classes/UIAlertController+Window.m
@@ -12,6 +12,7 @@
 @interface UIAlertController (Private)
 
 @property (nonatomic, strong) UIWindow *alertWindow;
+@property (nonatomic, strong) UIColor *tintColor;
 
 @end
 
@@ -27,9 +28,25 @@
     return objc_getAssociatedObject(self, @selector(alertWindow));
 }
 
+@dynamic tintColor;
+
+- (void)setTintColor:(UIColor *)tintColor {
+    objc_setAssociatedObject(self, @selector(tintColor), tintColor, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (UIColor *)tintColor {
+    return objc_getAssociatedObject(self, @selector(tintColor));
+}
+
 @end
 
 @implementation UIAlertController (Window)
+
++ (instancetype)alertControllerWithTitle:(NSString *)title message:(NSString *)message preferredStyle:(UIAlertControllerStyle)preferredStyle tintColor:(UIColor *)tintColor {
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:preferredStyle];
+    alertController.tintColor = tintColor;
+    return alertController;
+}
 
 - (void)show {
     [self show:YES];
@@ -37,6 +54,7 @@
 
 - (void)show:(BOOL)animated {
     self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    [self.alertWindow setTintColor:self.tintColor];
     self.alertWindow.rootViewController = [[UIViewController alloc] init];
     self.alertWindow.windowLevel = UIWindowLevelAlert + 1;
     [self.alertWindow makeKeyAndVisible];


### PR DESCRIPTION
…on the UIWindow (alertWindow) that is created to present the alert controllers

I noticed that because this is creating a new UIWindow to present an alert controller my saved tintColor that i set in the UIWindow of my appDelegate was not being honored. I added a tintColor property & convenience alert controller init method to set the new tintColor property.
