### PR TITLE
Prevented crash when [alert show] is called twice in a row.

### DIFF
--- a/Pod/Classes/UIAlertController+Window.m
+++ b/Pod/Classes/UIAlertController+Window.m
@@ -36,6 +36,10 @@
 }
 
 - (void)show:(BOOL)animated {
+    if (self.presentingViewController) {
+        return;
+    }
+    
     self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     self.alertWindow.rootViewController = [[UIViewController alloc] init];
     self.alertWindow.windowLevel = UIWindowLevelAlert + 1;


### PR DESCRIPTION
I have encountered crash with this library when the UIAlertController has been presented twice in a row. Here is a simple fix to prevent issues like that.